### PR TITLE
Default Google Maps API to HTTPS (gh-pages)

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -35,7 +35,7 @@
 </head>
 <body>
   <div class="preloader"></div>
-  <script src="http://maps.google.com/maps/api/js?sensor=false"></script>
+  <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
   <script src="bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes issues when enforcing HTTPS connections.

```
Uncaught Error: tried to use Google API without "google.maps" in global scope
  try using 'google-panorama-by-location/node.js' instead
```

(gh-pages-branch part of pr)
